### PR TITLE
Fix reset mask for Sudoku bits

### DIFF
--- a/include/SudokuBits.hpp
+++ b/include/SudokuBits.hpp
@@ -327,7 +327,7 @@ public:
 
     inline constexpr void ResetValue(std::size_t row, std::size_t col, std::size_t square, DataType value)
     {
-        FlagType mask = ~(1 << (value - 1));
+        FlagType mask = ~(FlagType(1ULL << (value - 1)));
         m_bits[row] &= mask;
         m_bits[size + col] &= mask;
         m_bits[size * 2 + square] &= mask;


### PR DESCRIPTION
## Summary
- fix bit reset in `SudokuBits::ResetValue` when dealing with large boards

## Testing
- `cmake -B build -S .` *(fails: CMake 3.30 required)*

------
https://chatgpt.com/codex/tasks/task_e_6843165a483c832ba58853f839038645