### PR TITLE
Fix CMake version requirement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Gabriel Matte
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# SudokuSolver
+
+Este projeto implementa um resolvedor de Sudoku em C++23 com duas abordagens principais: **Backtracking** e **Dancing Links (Algorithm X)**. Há ainda uma pequena interface utilizando **SFML** para visualizar o tabuleiro, bem como testes e benchmarks.
+
+## Dependências
+
+As dependências são gerenciadas via [vcpkg](https://github.com/microsoft/vcpkg) (o repositório já inclui o submódulo). As principais bibliotecas utilizadas são:
+
+- SFML
+- Boost (dynamic_bitset)
+- pcg
+- GoogleTest
+- Google Benchmark
+
+Certifique-se de inicializar o submódulo após clonar o repositório:
+
+```bash
+git submodule update --init --recursive
+```
+
+Em ambientes Linux pode ser necessário instalar alguns utilitários para que o
+`vcpkg` consiga compilar todas as bibliotecas, em especial o port `alsa`.
+Execute:
+
+```bash
+sudo apt-get install autoconf automake libtool
+```
+
+## Como compilar
+
+Utilize o **CMake** (versão >= 3.30.0) e um compilador com suporte a C++23.
+
+```bash
+# Configuração
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release
+
+# Compilação
+cmake --build build -j$(nproc)
+```
+
+No Windows é possível usar os `presets` já configurados:
+
+```bash
+cmake --preset VisualStudio-release
+cmake --build out/build/VisualStudio-release --config Release
+```
+
+## Executando
+
+Após a compilação o executável principal estará em `build/SudokuSolver` (ou na pasta correspondente do preset). Para executar:
+
+```bash
+./build/SudokuSolver
+```
+
+Também é possível rodar os benchmarks:
+
+```bash
+./build/SudokuSolver_BENCHMARK
+```
+
+## Testes
+
+Os testes unitários usam GoogleTest. Para gerar e executar:
+
+```bash
+cmake --build build --target SudokuSolver_TEST
+ctest --test-dir build --output-on-failure
+```
+
+## Licença
+
+Este projeto está licenciado sob os termos da licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
+
+## Contribuindo
+
+Pull requests são bem-vindos! Sinta-se livre para abrir *issues* ou propor melhorias.


### PR DESCRIPTION
## Summary
- require CMake 3.30.0 explicitly
- document updated requirement in the README

## Testing
- `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE=Release` *(fails: CMake 3.28.3 is lower than required 3.30.0)*

------
https://chatgpt.com/codex/tasks/task_e_68431d08becc832bbbd22654441593f5